### PR TITLE
Update findAndMount.sh for RONIN LINK

### DIFF
--- a/findAndMount.sh
+++ b/findAndMount.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -x
 
 # install the nvme tools
-#apt-get update >& /dev/null
-#apt install nvme-cli -y >& /dev/null
+#sudo apt-get update >& /dev/null
+#sudo apt install nvme-cli -y >& /dev/null
 
 # Get any unmounted and unpartitioned ephemeral drives. We assume these would
 # have been ignored upon launch - so we can offer to partition them, put file systems
@@ -12,7 +12,7 @@ getUnmountedEphemeralDrives() {
     ALLDISKS=$(lsblk --noheadings --raw -o NAME,TYPE|grep nvme|awk '$2=="disk" {print $1}')
     for disk in $ALLDISKS
     do
-	nvme id-ctrl -v /dev/${disk}|grep '^mn '| grep "Instance">&/dev/null
+	sudo nvme id-ctrl -v /dev/${disk}|grep '^mn '| grep "Instance">&/dev/null
             if [ $? -eq 0 ]; 
 	    then
 		DISKS="$DISKS ${disk}"
@@ -36,7 +36,7 @@ getUnmountedEphemeralDrives() {
     
     for i in $RAW
     do
-        ID=$(nvme id-ctrl -v $i | grep "0000:" | awk '{print $NF}' | sed 's/\.//g' | sed 's/^"//' | sed 's/"$//' | sed 's/:.*//' | sed 's/\/dev\///')
+        ID=$(sudo nvme id-ctrl -v $i | grep "0000:" | awk '{print $NF}' | sed 's/\.//g' | sed 's/^"//' | sed 's/"$//' | sed 's/:.*//' | sed 's/\/dev\///')
 	STRIP=$(echo $i | awk -F '/' '{print $3}')
 	SIZE=$(lsblk | grep $STRIP | awk 'NR==1{print $4}')
 	MOUNTPOINT="/mnt/$ID" 
@@ -53,7 +53,7 @@ getUnmountedEmptyEBSDrives() {
 ')
     for disk in $ALLDISKS
     do
-	nvme id-ctrl -v /dev/${disk}|grep '^mn '| grep "Amazon Elastic Block Store">&/dev/null
+	sudo nvme id-ctrl -v /dev/${disk}|grep '^mn '| grep "Amazon Elastic Block Store">&/dev/null
             if [ $? -eq 0 ]; 
 	    then
 		DISKS="$DISKS ${disk}"
@@ -88,7 +88,7 @@ getUnmountedEmptyEBSDrives() {
     
     for i in $RAW
     do
-        ID=$(nvme id-ctrl -v $i | grep "0000:" | awk '{print $NF}' | sed 's/\.//g' | sed 's/^"//' | sed 's/"$//' | sed 's/:.*//' | sed 's/\/dev\///')
+        ID=$(sudo nvme id-ctrl -v $i | grep "0000:" | awk '{print $NF}' | sed 's/\.//g' | sed 's/^"//' | sed 's/"$//' | sed 's/:.*//' | sed 's/\/dev\///')
 	STRIP=$(echo $i | awk -F '/' '{print $3}')
 	SIZE=$(lsblk | grep $STRIP | awk 'NR==1{print $4}')
 	MOUNTPOINT="/mnt/$ID" # Need to figure out a way to keep mount point bound to a drive ID so it doesn't get messed up - this might be better than using "volume1" etc?
@@ -105,7 +105,7 @@ getUnmountedEBSDrivesAndPartitionsWithData() {
     # limit to EBS only
     for disk in $UNMOUNTEDDISKS
     do
-	nvme id-ctrl -v /dev/${disk}|grep '^mn '| grep "Amazon Elastic Block Store">&/dev/null
+	sudo nvme id-ctrl -v /dev/${disk}|grep '^mn '| grep "Amazon Elastic Block Store">&/dev/null
             if [ $? -eq 0 ]; 
 	    then
 		DISKS="$DISKS ${disk}"
@@ -182,7 +182,7 @@ getUnmountedEBSDrivesAndPartitionsWithData() {
     
     for i in $FULLPART
     do
-        ID=$(nvme id-ctrl -v $i | grep "0000:" | awk '{print $NF}' | sed 's/\.//g' | sed 's/^"//' | sed 's/"$//' | sed 's/:.*//' | sed 's/\/dev\///')
+        ID=$(sudo nvme id-ctrl -v $i | grep "0000:" | awk '{print $NF}' | sed 's/\.//g' | sed 's/^"//' | sed 's/"$//' | sed 's/:.*//' | sed 's/\/dev\///')
 	STRIP=$(echo $i | awk -F '/' '{print $3}')
 	SIZE=$(lsblk | grep $STRIP | awk 'NR==1{print $4}')
 	MOUNTPOINT="/mnt/$ID" # Need to figure out a way to keep mount point bound to a drive ID so it doesn't get messed up - this might be better than using "volume1" etc?
@@ -191,7 +191,7 @@ getUnmountedEBSDrivesAndPartitionsWithData() {
     
     for i in $RESIZED
     do
-        ID=$(nvme id-ctrl -v $i | grep "0000:" | awk '{print $NF}' | sed 's/\.//g' | sed 's/^"//' | sed 's/"$//' | sed 's/:.*//' | sed 's/\/dev\///')
+        ID=$(sudo nvme id-ctrl -v $i | grep "0000:" | awk '{print $NF}' | sed 's/\.//g' | sed 's/^"//' | sed 's/"$//' | sed 's/:.*//' | sed 's/\/dev\///')
 	STRIP=$(echo $i | awk -F '/' '{print $3}')
 	SIZE=$(lsblk | grep $STRIP | awk 'NR==1{print $4}')
 	MOUNTPOINT="/mnt/$ID" # Need to figure out a way to keep mount point bound to a drive ID so it doesn't get messed up - this might be better than using "volume1" etc?

--- a/findAndMount.sh
+++ b/findAndMount.sh
@@ -40,7 +40,7 @@ getUnmountedEphemeralDrives() {
 	STRIP=$(echo $i | awk -F '/' '{print $3}')
 	SIZE=$(lsblk | grep $STRIP | awk 'NR==1{print $4}')
 	MOUNTPOINT="/mnt/$ID" 
-	echo "RONINLINK | EPHEMERAL $ID $SIZE BLANK $MOUNTPOINT"
+	echo "RONINLINK | EPHEMERAL | $ID | $SIZE | BLANK | $MOUNTPOINT"
     done
     
  }
@@ -92,7 +92,7 @@ getUnmountedEmptyEBSDrives() {
 	STRIP=$(echo $i | awk -F '/' '{print $3}')
 	SIZE=$(lsblk | grep $STRIP | awk 'NR==1{print $4}')
 	MOUNTPOINT="/mnt/$ID" # Need to figure out a way to keep mount point bound to a drive ID so it doesn't get messed up - this might be better than using "volume1" etc?
-	echo "RONINLINK | EBS /dev/$ID $SIZE BLANK $MOUNTPOINT"
+	echo "RONINLINK | EBS | /dev/$ID | $SIZE | BLANK | $MOUNTPOINT"
     done
     
 }
@@ -186,7 +186,7 @@ getUnmountedEBSDrivesAndPartitionsWithData() {
 	STRIP=$(echo $i | awk -F '/' '{print $3}')
 	SIZE=$(lsblk | grep $STRIP | awk 'NR==1{print $4}')
 	MOUNTPOINT="/mnt/$ID" # Need to figure out a way to keep mount point bound to a drive ID so it doesn't get messed up - this might be better than using "volume1" etc?
-	echo "RONINLINK | EBS /dev/$ID $SIZE DATA $MOUNTPOINT"
+	echo "RONINLINK | EBS | /dev/$ID | $SIZE | DATA | $MOUNTPOINT"
     done
     
     for i in $RESIZED
@@ -195,7 +195,7 @@ getUnmountedEBSDrivesAndPartitionsWithData() {
 	STRIP=$(echo $i | awk -F '/' '{print $3}')
 	SIZE=$(lsblk | grep $STRIP | awk 'NR==1{print $4}')
 	MOUNTPOINT="/mnt/$ID" # Need to figure out a way to keep mount point bound to a drive ID so it doesn't get messed up - this might be better than using "volume1" etc?
-	echo "RONINLINK | RESZIED /dev/$ID $SIZE DATA $MOUNTPOINT"
+	echo "RONINLINK | RESZIED | /dev/$ID | $SIZE | DATA | $MOUNTPOINT"
     done
     
 }

--- a/findAndMount.sh
+++ b/findAndMount.sh
@@ -25,7 +25,7 @@ getUnmountedEphemeralDrives() {
     RAW=""
     for i in $DISKS
     do
-	found=`grep "$i" <<< ${PARTS}`
+	found=$(grep "$i" <<< ${PARTS})
 	if [ -z $found ]
 	then
 	    RAW="$RAW /dev/$i"
@@ -67,7 +67,7 @@ getUnmountedEmptyEBSDrives() {
     NOPART=""
     for i in $DISKS
     do
-	found=`grep "$i" <<< ${PARTS}`
+	found=$(grep "$i" <<< ${PARTS})
 	if [ -z $found ]
 	then
 	    NOPART="$NOPART /dev/$i"
@@ -119,7 +119,7 @@ getUnmountedEBSDrivesAndPartitionsWithData() {
     NOPART=""
     for i in $DISKS
     do
-	found=`grep "$i" <<< ${MOUNTEDPARTS}`
+	found=$(grep "$i" <<< ${MOUNTEDPARTS})
 	if [ -z $found ]
 	then
 	    NOPART="$NOPART $i"
@@ -135,7 +135,7 @@ getUnmountedEBSDrivesAndPartitionsWithData() {
     DRIVES=""
     for i in $NOPART
     do
-	found=`grep "$i" <<< ${UNMOUNTEDPARTS}`
+	found=$(grep "$i" <<< ${UNMOUNTEDPARTS})
 	if [ -z $found ]
 	then
 	    DRIVES="${DRIVES} $i"


### PR DESCRIPTION
Some recommendations for RONIN Link integration: Want the user to be able to automatically mount partitioned drives that don't require filesystem extension (i.e. restored from backup but not resized) but identify partitioned drives that do require a filesystem extension (i.e. drive resized when restored from a backup - user will need to perform extension themselves but we can tell them which drives need this) - I have added this identification to the script so they are stored in two separate variables now. Have also added some RONIN LINK lines that will assist with displaying the information for each of the drives so that we can read it in and create the required html elements dynamically - IDs will match up with RONIN interface e.g. /dev/sdd rather than nvme1n1 etc. Partition and mount drive function will likely need to be split into two functions and put into separate scripts for RONIN LINK - mount only script (for drives that already have a file system or full partition and simply need to be mounted) and partition and mount script (for empty EBS Drives and ephemeral drives that require both). Not sure whether we can add the functionality to determine whether a drive is General, Magnetic, Hot, Cold for RONIN LINK - from what I've read we don't have the required permissions on the machines to do this?